### PR TITLE
Add top match recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ The API exposes endpoints under `/api/clients`:
 - `PUT /api/clients/{id}` – update a client
 - `DELETE /api/clients/{id}` – remove a client
 
+Additional match related endpoints under `/api/matches`:
+
+- `POST /api/matches` – create a match record between two clients
+- `GET /api/matches/recommendations/{clientId}?top=5` – find the top matches for a client. The score is returned on a 0‑10 scale along with text reasons explaining the compatibility.
+
 
 
 ## Web UI
 
 A simple HTML interface is served from the `wwwroot` folder of `MatchingApp.Api`.
 When running the application, navigate to `https://localhost:5001/` (or the configured base URL) to access `index.html`.
-The page now supports creating clients, fetching individual records, listing all clients and creating matches.
-Natal chart details are shown for each client and match scores are visualised with a progress bar.
+The page now supports creating clients, fetching individual records, listing all clients, creating matches and finding recommendations.
+Natal chart details are shown for each client and match scores are visualised with a progress bar. Recommended matches include short textual reasons describing the compatibility.

--- a/src/MatchingApp.Api/Models/CompatibilityResult.cs
+++ b/src/MatchingApp.Api/Models/CompatibilityResult.cs
@@ -1,0 +1,8 @@
+namespace MatchingApp.Api.Models
+{
+    public class CompatibilityResult
+    {
+        public double Score { get; set; }
+        public List<string> Reasons { get; } = new();
+    }
+}

--- a/src/MatchingApp.Api/Models/MatchRecommendation.cs
+++ b/src/MatchingApp.Api/Models/MatchRecommendation.cs
@@ -1,0 +1,9 @@
+namespace MatchingApp.Api.Models
+{
+    public class MatchRecommendation
+    {
+        public Client? Client { get; set; }
+        public double Score { get; set; }
+        public List<string> Reasons { get; set; } = new();
+    }
+}

--- a/src/MatchingApp.Api/Services/MatchService.cs
+++ b/src/MatchingApp.Api/Services/MatchService.cs
@@ -27,5 +27,33 @@ namespace MatchingApp.Api.Services
 
             return score;
         }
+
+        public CompatibilityResult CalculateCompatibilityDetail(NatalChart? a, NatalChart? b)
+        {
+            var result = new CompatibilityResult();
+            if (a == null || b == null)
+            {
+                result.Reasons.Add("Missing natal chart information");
+                return result;
+            }
+
+            if (!string.IsNullOrEmpty(a.SunSign) && a.SunSign == b.SunSign)
+            {
+                result.Score += 4;
+                result.Reasons.Add($"Both share Sun sign {a.SunSign}");
+            }
+            if (!string.IsNullOrEmpty(a.MoonSign) && a.MoonSign == b.MoonSign)
+            {
+                result.Score += 3;
+                result.Reasons.Add($"Both share Moon sign {a.MoonSign}");
+            }
+            if (!string.IsNullOrEmpty(a.Ascendant) && a.Ascendant == b.Ascendant)
+            {
+                result.Score += 3;
+                result.Reasons.Add($"Both share Ascendant {a.Ascendant}");
+            }
+
+            return result;
+        }
     }
 }

--- a/src/MatchingApp.Api/wwwroot/index.html
+++ b/src/MatchingApp.Api/wwwroot/index.html
@@ -121,6 +121,18 @@
             <progress id="match-score" value="0" max="100" style="width:100%; display:none;"></progress>
             <div id="match-percent"></div>
         </section>
+
+        <section>
+            <h2>Find Matches</h2>
+            <label>Client ID:
+                <input type="number" id="find-id">
+            </label>
+            <label>Top N:
+                <input type="number" id="find-top" value="5">
+            </label>
+            <button id="find-btn">Find</button>
+            <div id="find-result" class="result"></div>
+        </section>
     </main>
     <script>
         const apiBase = '/api/clients';
@@ -194,6 +206,20 @@
                 bar.style.display = 'none';
                 percent.textContent = '';
             }
+        });
+
+        document.getElementById('find-btn').addEventListener('click', async () => {
+            const id = document.getElementById('find-id').value;
+            let top = document.getElementById('find-top').value || 5;
+            if (!id) return;
+            const res = await fetch(`${matchBase}/recommendations/${id}?top=${top}`);
+            if (!res.ok) return;
+            const data = await res.json();
+            document.getElementById('find-result').innerHTML = data.map(r =>
+                `<div>${renderClient(r.client)}<br>Score: ${r.score}/10<ul>` +
+                r.reasons.map(s => `<li>${s}</li>`).join('') +
+                '</ul></div>'
+            ).join('<hr>');
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add compatibility result models
- enrich `MatchService` with detailed score calculation
- expose `/api/matches/recommendations/{id}` to list top matches
- extend the web UI for finding matches
- document the new endpoint and UI features

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e33240988832e9e993711036b925f