### PR TITLE
Fix match scoring and self-match filtering

### DIFF
--- a/src/MatchingApp.Api/Controllers/MatchesController.cs
+++ b/src/MatchingApp.Api/Controllers/MatchesController.cs
@@ -94,7 +94,10 @@ namespace MatchingApp.Api.Controllers
                 return NotFound();
             }
 
-            var others = await _context.Clients.Include(c => c.NatalChart).Where(c => c.Id != clientId).ToListAsync();
+            var others = await _context.Clients
+                .Include(c => c.NatalChart)
+                .Where(c => c.Id != clientId && c.Name != client.Name)
+                .ToListAsync();
 
             var recs = others.Select(o =>
             {

--- a/src/MatchingApp.Api/Services/MatchService.cs
+++ b/src/MatchingApp.Api/Services/MatchService.cs
@@ -53,6 +53,9 @@ namespace MatchingApp.Api.Services
                 result.Reasons.Add($"Both share Ascendant {a.Ascendant}");
             }
 
+            // Scale score to a 0-100 range for percentage display
+            result.Score *= 10;
+
             return result;
         }
     }


### PR DESCRIPTION
## Summary
- avoid recommending matches with the same name as the current client
- scale compatibility score to 0-100 so the UI percentage is correct

## Testing
- `dotnet build src/MatchingApp.Api/MatchingApp.Api.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4698c388832e92ff95e58f58d48c