### PR TITLE
Switch DB to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Matching-App
 
-This repository contains a starter ASP.NET Core Web API for a matchmaking application. The API uses Entity Framework Core with SQL Server.
+This repository contains a starter ASP.NET Core Web API for a matchmaking application. The API uses Entity Framework Core with SQLite by default.
 
 ## Building
 
@@ -49,7 +49,7 @@ Pass the returned token in the `X-Auth-Token` header when calling match related 
 
 ## Database Setup
 
-Entity Framework Core migrations are included. To create or update the database run from the `src/MatchingApp.Api` directory:
+Entity Framework Core migrations are included. The API uses a local SQLite file named `matchingapp.db`. To create or update the database run from the `src/MatchingApp.Api` directory:
 
 ```bash
 dotnet ef database update

--- a/src/MatchingApp.Api/Program.cs
+++ b/src/MatchingApp.Api/Program.cs
@@ -19,7 +19,7 @@ builder.Services.AddSingleton<AuthService>();
 
 
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
 

--- a/src/MatchingApp.Api/appsettings.json
+++ b/src/MatchingApp.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=KAKMA74\\SQLDEV2022;Database=MatchingApp;Trusted_Connection=True;MultipleActiveResultSets=true;Encrypt=False"
+    "DefaultConnection": "Data Source=matchingapp.db"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- use SQLite instead of SQL Server
- update default connection string
- document new database

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f991e8a98832e8b55f4ac109f106d