### PR TITLE
Add detailed compatibility breakdown

### DIFF
--- a/src/MatchingApp.Api/Controllers/MatchesController.cs
+++ b/src/MatchingApp.Api/Controllers/MatchesController.cs
@@ -162,7 +162,9 @@ namespace MatchingApp.Api.Controllers
                 {
                     Client = o,
                     Score = detail.Score,
-                    Reasons = detail.Reasons
+                    StarRating = detail.StarRating,
+                    Reasons = detail.Reasons,
+                    Breakdown = detail.Breakdown
                 };
             })
             .OrderByDescending(r => r.Score)

--- a/src/MatchingApp.Api/Models/CompatibilityResult.cs
+++ b/src/MatchingApp.Api/Models/CompatibilityResult.cs
@@ -3,6 +3,8 @@ namespace MatchingApp.Api.Models
     public class CompatibilityResult
     {
         public double Score { get; set; }
+        public double StarRating { get; set; }
         public List<string> Reasons { get; } = new();
+        public List<SignCompatibility> Breakdown { get; } = new();
     }
 }

--- a/src/MatchingApp.Api/Models/MatchRecommendation.cs
+++ b/src/MatchingApp.Api/Models/MatchRecommendation.cs
@@ -4,6 +4,8 @@ namespace MatchingApp.Api.Models
     {
         public Client? Client { get; set; }
         public double Score { get; set; }
+        public double StarRating { get; set; }
         public List<string> Reasons { get; set; } = new();
+        public List<SignCompatibility> Breakdown { get; set; } = new();
     }
 }

--- a/src/MatchingApp.Api/Models/SignCompatibility.cs
+++ b/src/MatchingApp.Api/Models/SignCompatibility.cs
@@ -1,0 +1,10 @@
+namespace MatchingApp.Api.Models
+{
+    public class SignCompatibility
+    {
+        public string Planet { get; set; } = string.Empty;
+        public string? SignA { get; set; }
+        public string? SignB { get; set; }
+        public bool Match { get; set; }
+    }
+}

--- a/src/MatchingApp.Api/Services/MatchService.cs
+++ b/src/MatchingApp.Api/Services/MatchService.cs
@@ -32,13 +32,23 @@ namespace MatchingApp.Api.Services
 
             // Scale to 0-100 percentage (11 possible matches)
             result.Score = result.Score / 11.0 * 100.0;
+            result.StarRating = Math.Round(result.Score / 20.0, 1);
 
             return result;
         }
 
         private void CompareSign(CompatibilityResult result, string? a, string? b, string label)
         {
-            if (!string.IsNullOrEmpty(a) && a == b)
+            bool match = !string.IsNullOrEmpty(a) && a == b;
+            result.Breakdown.Add(new SignCompatibility
+            {
+                Planet = label,
+                SignA = a,
+                SignB = b,
+                Match = match
+            });
+
+            if (match)
             {
                 result.Score += 1;
                 result.Reasons.Add($"Both share {label} sign {a}");

--- a/src/MatchingApp.Api/wwwroot/app.html
+++ b/src/MatchingApp.Api/wwwroot/app.html
@@ -194,6 +194,20 @@
             transition: width .5s;
         }
 
+        .match-stars {
+            color: #f5c518;
+            font-size: 1.1rem;
+            margin-top: .4rem;
+        }
+
+        .breakdown-list {
+            margin-top: .4rem;
+            margin-bottom: .2rem;
+            padding-left: 1.1rem;
+            color: #555;
+            font-size: .95rem;
+        }
+
         .match-actions {
             margin-top: .6rem;
         }
@@ -642,8 +656,13 @@
                 return;
             }
 
-            list.innerHTML = data.map(m =>
-                `<div class="match-card">
+            list.innerHTML = data.map(m => {
+                const full = Math.round(m.starRating);
+                const stars = '★'.repeat(full) + '☆'.repeat(5 - full);
+                const details = m.breakdown.map(d =>
+                    `<li>${d.planet}: ${d.signA ?? '?'} vs ${d.signB ?? '?'}${d.match ? ' ✓' : ''}</li>`
+                ).join('');
+                return `<div class="match-card">
                         <div class="match-avatar">${m.client.name.charAt(0)}</div>
                         <div class="match-details">
                             <div class="match-name">${m.client.name}</div>
@@ -653,14 +672,16 @@
                                     <div class="score-bar-fill" style="width:${m.score.toFixed(1)}%"></div>
                                 </div>
                             </div>
+                            <div class="match-stars">${stars}</div>
+                            <ul class="breakdown-list">${details}</ul>
                             <div class="match-actions">
                                 <button onclick="sendRequest(${m.client.id}, 'like')">Like</button>
                                 <button onclick="sendRequest(${m.client.id}, 'wink')">Wink</button>
                                 <button onclick="sendMessageRequest(${m.client.id})">Message</button>
                             </div>
                         </div>
-                    </div>`
-            ).join('');
+                    </div>`;
+            }).join('');
         }
 
         async function loadMyMatches() {


### PR DESCRIPTION
## Summary
- extend server match data to include star rating and sign breakdown
- expose breakdown and star rating in recommendations endpoint
- display star ratings and compatibility details in web UI

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcd23fbb0832e8844f09397297f97