### PR TITLE
Add match details toggle

### DIFF
--- a/src/MatchingApp.Api/wwwroot/app.html
+++ b/src/MatchingApp.Api/wwwroot/app.html
@@ -693,9 +693,6 @@
                                 <ul class="breakdown-list">${details}</ul>
                             </div>
 
-                            <div class="match-stars">${stars}</div>
-                            <ul class="breakdown-list">${details}</ul>
-
                             <div class="match-actions">
                                 <button onclick="sendRequest(${m.client.id}, 'like')">Like</button>
                                 <button onclick="sendRequest(${m.client.id}, 'wink')">Wink</button>


### PR DESCRIPTION
## Summary
- only show compatibility info when the user clicks "Show Details" on a match card

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd5050f38832eb212529d3d794b0e