### PR TITLE
Remove message button from matches list

### DIFF
--- a/src/MatchingApp.Api/wwwroot/app.html
+++ b/src/MatchingApp.Api/wwwroot/app.html
@@ -23,7 +23,8 @@
             color: #333;
             display: flex;
             flex-direction: column;
-            justify-content: center;
+            align-items: center;
+            padding-top: 1rem;
         }
 
         main {
@@ -696,7 +697,6 @@
                             <div class="match-actions">
                                 <button onclick="sendRequest(${m.client.id}, 'like')">Like</button>
                                 <button onclick="sendRequest(${m.client.id}, 'wink')">Wink</button>
-                                <button onclick="sendMessageRequest(${m.client.id})">Message</button>
                             </div>
                         </div>
                     </div>`;


### PR DESCRIPTION
## Summary
- keep page top visible by aligning items to the top and padding
- remove the Message option in the Find Matches listing

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6320d58832ebac11024ec0dd9ac