### PR TITLE
Fix session expiry popup in sendRequest

### DIFF
--- a/src/MatchingApp.Api/wwwroot/app.html
+++ b/src/MatchingApp.Api/wwwroot/app.html
@@ -884,6 +884,12 @@
                 if (type === 'like' || type === 'wink') {
                     loadMyMatches();
                 }
+            } else if (res.status === 401) {
+                localStorage.removeItem('authToken');
+                localStorage.removeItem('clientId');
+                currentClient = null;
+                showLanding();
+                showLoginError('Session expired. Please log in again.');
             } else if (res.status === 403) {
                 if (type === 'message') {
                     showAlert('You can only message users you have matched with.');


### PR DESCRIPTION
## Summary
- avoid showing a popup when contact requests fail due to an expired session
- if the API returns 401, clear stored credentials and show the inline login error

## Testing
- `dotnet build src/MatchingApp.Api/MatchingApp.Api.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe29e072c832ea5c53408e5da8a5d